### PR TITLE
Remove k8s manifests for zipkin and prom; update observability pkg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.7
+        version: v2.8
 
     - name: Run tests
       run: go test -race -vet=off ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,6 +39,7 @@ linters:
     - makezero
     - mirror
     - misspell
+    - modernize
     - nakedret
     - nilerr
     - nilnil
@@ -103,6 +104,9 @@ linters:
       - linters:
           - revive # disable "should have a package comment"
         text: "package comment"
+      - linters:
+          - modernize
+        text: "interface{} can be replaced by any"
     paths:
       - docs
       - examples$

--- a/.k8s/config.yaml
+++ b/.k8s/config.yaml
@@ -27,48 +27,7 @@ data:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-    name: zipkin-config
-    namespace: game-library
-data:
-    ZIPKIN_UI_BASEPATH: "/_trace/zipkin"
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
     name: graylog-config
     namespace: game-library
 data:
     GRAYLOG_HTTP_EXTERNAL_URI: "https://_K8S_URL_/_log/"
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-    name: prometheus-config
-    namespace: game-library
-data:
-    prometheus.yml: |
-        global:
-            scrape_interval: 15s
-            evaluation_interval: 15s
-            scrape_timeout: 1s
-          
-        scrape_configs:
-          - job_name: 'prometheus'
-            # because of ingress prefix
-            metrics_path: '/_metrics/metrics'
-            static_configs:
-              - targets: [ 'localhost:9090' ]
-              
-          - job_name: 'game-library'
-            kubernetes_sd_configs:
-              - role: endpoints
-                namespaces:
-                    names:
-                      - game-library
-            relabel_configs:
-              - source_labels: [ __meta_kubernetes_service_name ]
-                action: keep
-                regex: game-library-service
-              - source_labels: [ __meta_kubernetes_endpoint_port_name ]
-                action: keep
-                regex: api

--- a/.k8s/config.yaml
+++ b/.k8s/config.yaml
@@ -21,6 +21,11 @@ data:
     GRAYLOG_ADDR: "graylog-service.game-library.svc.cluster.local:12201"
     S3_REGION: "auto"
     S3_BUCKET_NAME: "game-library"
+    S3_TIMEOUT: "10s"
+    IGDB_API_TIMEOUT: "10s"
+    OPENAI_MODERATION_MODEL: "omni-moderation-latest"
+    OPENAI_VISION_MODEL: "gpt-5-nano"
+    OPENAI_API_TIMEOUT: "30s"
     AUTHAPI_ADDRESS: "game-library-auth-service.game-library.svc.cluster.local.:9000"
     AUTHAPI_TIMEOUT: "2s"
 ---

--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -93,39 +93,6 @@ spec:
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-    name: zipkin-deployment
-    namespace: game-library
-    labels:
-        app: zipkin
-spec:
-    replicas: 1
-    strategy:
-        type: Recreate
-    selector:
-        matchLabels:
-            app: zipkin
-    template:
-        metadata:
-            labels:
-                app: zipkin
-        spec:
-            containers:
-              - name: zipkin
-                image: openzipkin/zipkin:3.5
-                ports:
-                  - name: zipkin
-                    containerPort: 9411
-                envFrom:
-                  - configMapRef:
-                      name: zipkin-config
-            hostAliases:
-              - ip: _K8S_IP_
-                hostnames:
-                  - _K8S_URL_
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
     name: redis-deployment
     namespace: game-library
     labels:
@@ -190,54 +157,6 @@ spec:
                   - name: gelf
                     containerPort: 12201
                     protocol: UDP
-            hostAliases:
-              - ip: _K8S_IP_
-                hostnames:
-                  - _K8S_URL_
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-    name: prometheus-deployment
-    namespace: game-library
-    labels:
-        app: prometheus
-spec:
-    replicas: 1
-    strategy:
-        # use this because of lock db directory error
-        type: Recreate
-    selector:
-        matchLabels:
-            app: prometheus
-    template:
-        metadata:
-            labels:
-                app: prometheus
-        spec:
-            volumes:
-              - name: prometheus-config-volume
-                configMap:
-                    name: prometheus-config
-              - name: prometheus-data
-                persistentVolumeClaim:
-                    claimName: prometheus-data-pvc
-            containers:
-              - name: prometheus
-                image: prom/prometheus:v3.2.1
-                args:
-                  - "--config.file=/etc/prometheus/prometheus.yml"
-                  - "--storage.tsdb.path=/prometheus"
-                  # for ingress path /_metrics/
-                  - "--web.external-url=/_metrics"
-                ports:
-                  - name: prometheus
-                    containerPort: 9090
-                volumeMounts:
-                  - name: prometheus-config-volume
-                    mountPath: /etc/prometheus
-                  - name: prometheus-data
-                    mountPath: /prometheus
             hostAliases:
               - ip: _K8S_IP_
                 hostnames:

--- a/.k8s/ingress.yaml
+++ b/.k8s/ingress.yaml
@@ -43,11 +43,11 @@ spec:
                     service:
                         name: game-library-service
                         port:
-                            number: 6060
+                            name: debug
               - path: /_log(/|$)(.*)
                 pathType: Prefix
                 backend:
                     service:
                         name: graylog-service
                         port:
-                            number: 9000
+                            name: http

--- a/.k8s/ingress.yaml
+++ b/.k8s/ingress.yaml
@@ -44,13 +44,6 @@ spec:
                         name: game-library-service
                         port:
                             number: 6060
-              - path: /_trace(/|$)(.*)
-                pathType: Prefix
-                backend:
-                    service:
-                        name: zipkin-service
-                        port:
-                            number: 9411
               - path: /_log(/|$)(.*)
                 pathType: Prefix
                 backend:
@@ -58,25 +51,3 @@ spec:
                         name: graylog-service
                         port:
                             number: 9000
----
-kind: Ingress
-apiVersion: networking.k8s.io/v1
-metadata:
-    name: prometheus-ingress
-    namespace: game-library
-    annotations:
-        nginx.ingress.kubernetes.io/auth-type: basic
-        nginx.ingress.kubernetes.io/auth-secret: basic-auth
-        nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - game library'
-spec:
-    rules:
-        - host: _K8S_URL_
-          http:
-              paths:
-                  - path: /_metrics
-                    pathType: Prefix
-                    backend:
-                        service:
-                            name: prometheus-service
-                            port:
-                                number: 9090

--- a/.k8s/namespace.yaml
+++ b/.k8s/namespace.yaml
@@ -1,4 +1,0 @@
-kind: Namespace
-apiVersion: v1
-metadata:
-    name: game-library

--- a/.k8s/service.yaml
+++ b/.k8s/service.yaml
@@ -23,20 +23,6 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-    name: zipkin-service
-    namespace: game-library
-spec:
-    ports:
-      - protocol: TCP
-        name: zipkin
-        port: 9411
-        targetPort: zipkin
-    selector:
-        app: zipkin
----
-kind: Service
-apiVersion: v1
-metadata:
   name: redis-service
   namespace: game-library
 spec:
@@ -65,18 +51,3 @@ spec:
       targetPort: gelf
   selector:
     app: graylog
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: prometheus-service
-  namespace: game-library
-spec:
-  ports:
-    - protocol: TCP
-      name: prometheus
-      port: 9090
-      targetPort: prometheus
-  selector:
-    app: prometheus
-

--- a/.k8s/volume.yaml
+++ b/.k8s/volume.yaml
@@ -27,31 +27,3 @@ spec:
     requests:
       storage: 1Gi
   storageClassName: graylog-storage-class
----
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: prometheus-pv
-spec:
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: prometheus-storage-class
-  hostPath:
-    # make folder writable: chmod -R o+w prometheus
-    path: /data/prometheus
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: prometheus-data-pvc
-  namespace: game-library
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  storageClassName: prometheus-storage-class

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ generate-proto:
 
 generate: generate-proto generate-swag generate-mocks
 
-LINT_VERSION := v2.7
+LINT_VERSION := v2.8
 LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINT_VERSION)
 lint:
 	@golangci-lint version >/dev/null 2>&1 || { echo "Installing golangci-lint..."; go install ${LINT_PKG}; }

--- a/app.example.env
+++ b/app.example.env
@@ -22,6 +22,7 @@ IGDB_CLIENT_ID=*igdb-client-id*
 IGDB_CLIENT_SECRET=*igdb-client-secret*
 IGDB_TOKEN_URL=https://id.twitch.tv/oauth2/token
 IGDB_API_URL=https://api.igdb.com/v4/
+IGDB_API_TIMEOUT=10s
 
 # scheduler
 SCHED_FETCH_IGDB_GAMES="0 5 * * *"
@@ -44,12 +45,14 @@ S3_SECRET_ACCESS_KEY=*secret-access-key*
 S3_ENDPOINT=*s3-endpoint*
 S3_BUCKET_NAME=*game-library*
 S3_CDN_BASE_URL=*cdn-url*
+S3_TIMEOUT=10s
 
 # openai
 OPENAI_API_KEY=*sk-...*
 OPENAI_API_URL=https://api.openai.com/v1
 OPENAI_MODERATION_MODEL=omni-moderation-latest
 OPENAI_VISION_MODEL=gpt-5-nano
+OPENAI_API_TIMEOUT=30s
 
 # authapi client
 AUTHAPI_ADDRESS=localhost:9001

--- a/internal/appconf/settings.go
+++ b/internal/appconf/settings.go
@@ -46,10 +46,11 @@ type Zipkin struct {
 
 // IGDB represents settings for IGDB client
 type IGDB struct {
-	ClientID     string `mapstructure:"IGDB_CLIENT_ID"`
-	ClientSecret string `mapstructure:"IGDB_CLIENT_SECRET"`
-	TokenURL     string `mapstructure:"IGDB_TOKEN_URL"`
-	APIURL       string `mapstructure:"IGDB_API_URL"`
+	ClientID     string        `mapstructure:"IGDB_CLIENT_ID"`
+	ClientSecret string        `mapstructure:"IGDB_CLIENT_SECRET"`
+	TokenURL     string        `mapstructure:"IGDB_TOKEN_URL"`
+	APIURL       string        `mapstructure:"IGDB_API_URL"`
+	Timeout      time.Duration `mapstructure:"IGDB_API_TIMEOUT"`
 }
 
 // Scheduler represents settings for task scheduler
@@ -74,20 +75,22 @@ type Graylog struct {
 
 // S3 represents settings for S3 client
 type S3 struct {
-	Region          string `mapstructure:"S3_REGION"`
-	AccessKeyID     string `mapstructure:"S3_ACCESS_KEY_ID"`
-	SecretAccessKey string `mapstructure:"S3_SECRET_ACCESS_KEY"`
-	Endpoint        string `mapstructure:"S3_ENDPOINT"`
-	BucketName      string `mapstructure:"S3_BUCKET_NAME"`
-	CDNBaseURL      string `mapstructure:"S3_CDN_BASE_URL"`
+	Region          string        `mapstructure:"S3_REGION"`
+	AccessKeyID     string        `mapstructure:"S3_ACCESS_KEY_ID"`
+	SecretAccessKey string        `mapstructure:"S3_SECRET_ACCESS_KEY"`
+	Endpoint        string        `mapstructure:"S3_ENDPOINT"`
+	BucketName      string        `mapstructure:"S3_BUCKET_NAME"`
+	CDNBaseURL      string        `mapstructure:"S3_CDN_BASE_URL"`
+	Timeout         time.Duration `mapstructure:"S3_TIMEOUT"`
 }
 
 // OpenAI represents settings for OpenAI client
 type OpenAI struct {
-	APIKey          string `mapstructure:"OPENAI_API_KEY"`
-	APIURL          string `mapstructure:"OPENAI_API_URL"`
-	ModerationModel string `mapstructure:"OPENAI_MODERATION_MODEL"`
-	VisionModel     string `mapstructure:"OPENAI_VISION_MODEL"`
+	APIKey          string        `mapstructure:"OPENAI_API_KEY"`
+	APIURL          string        `mapstructure:"OPENAI_API_URL"`
+	ModerationModel string        `mapstructure:"OPENAI_MODERATION_MODEL"`
+	VisionModel     string        `mapstructure:"OPENAI_VISION_MODEL"`
+	Timeout         time.Duration `mapstructure:"OPENAI_API_TIMEOUT"`
 }
 
 // Log represents settings for logging
@@ -147,6 +150,9 @@ func (cfg *Cfg) Validate() error {
 	if cfg.IGDB.APIURL == "" {
 		return errors.New("IGDB_API_URL is required")
 	}
+	if cfg.IGDB.Timeout <= 0 {
+		return errors.New("IGDB_API_TIMEOUT must be greater than 0")
+	}
 
 	// scheduler
 	if cfg.Scheduler.FetchIGDBGames == "" {
@@ -197,6 +203,9 @@ func (cfg *Cfg) Validate() error {
 	if _, err := url.Parse(cfg.S3.CDNBaseURL); err != nil {
 		return errors.New("S3_CDN_BASE_URL is invalid")
 	}
+	if cfg.S3.Timeout <= 0 {
+		return errors.New("S3_TIMEOUT must be greater than 0")
+	}
 
 	// openai
 	if cfg.OpenAI.APIKey == "" {
@@ -210,6 +219,9 @@ func (cfg *Cfg) Validate() error {
 	}
 	if cfg.OpenAI.VisionModel == "" {
 		return errors.New("OPENAI_VISION_MODEL is required")
+	}
+	if cfg.OpenAI.Timeout <= 0 {
+		return errors.New("OPENAI_API_TIMEOUT must be greater than 0")
 	}
 
 	// log

--- a/internal/appconf/settings_test.go
+++ b/internal/appconf/settings_test.go
@@ -1,0 +1,365 @@
+package appconf_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/OutOfStack/game-library/internal/appconf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCfgValidateValidConfig(t *testing.T) {
+	cfg := validTestCfg()
+
+	err := cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestCfgValidateValidRedisTTLZero(t *testing.T) {
+	cfg := validTestCfg()
+	cfg.Redis.TTL = 0
+
+	err := cfg.Validate()
+
+	require.NoError(t, err)
+}
+
+func TestCfgValidateErrorCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *appconf.Cfg
+		mutate    func(*appconf.Cfg)
+		wantError string
+	}{
+		{
+			name:      "nil cfg",
+			cfg:       nil,
+			wantError: "cfg is nil",
+		},
+		{
+			name: "missing db dsn",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.DB.DSN = ""
+			},
+			wantError: "DB_DSN is required",
+		},
+		{
+			name: "missing app http address",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Web.HTTPAddress = ""
+			},
+			wantError: "APP_HTTP_ADDRESS is required",
+		},
+		{
+			name: "missing app debug address",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Web.DebugAddress = ""
+			},
+			wantError: "APP_DEBUG_ADDRESS is required",
+		},
+		{
+			name: "missing app grpc address",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Web.GRPCAddress = ""
+			},
+			wantError: "APP_GRPC_ADDRESS is required",
+		},
+		{
+			name: "invalid app read timeout",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Web.ReadTimeout = 0
+			},
+			wantError: "APP_READTIMEOUT must be greater than 0",
+		},
+		{
+			name: "invalid app write timeout",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Web.WriteTimeout = 0
+			},
+			wantError: "APP_WRITETIMEOUT must be greater than 0",
+		},
+		{
+			name: "missing zipkin reporter url",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Zipkin.ReporterURL = ""
+			},
+			wantError: "ZIPKIN_REPORTERURL is required",
+		},
+		{
+			name: "missing igdb client id",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.IGDB.ClientID = ""
+			},
+			wantError: "IGDB_CLIENT_ID is required",
+		},
+		{
+			name: "missing igdb client secret",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.IGDB.ClientSecret = ""
+			},
+			wantError: "IGDB_CLIENT_SECRET is required",
+		},
+		{
+			name: "missing igdb token url",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.IGDB.TokenURL = ""
+			},
+			wantError: "IGDB_TOKEN_URL is required",
+		},
+		{
+			name: "missing igdb api url",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.IGDB.APIURL = ""
+			},
+			wantError: "IGDB_API_URL is required",
+		},
+		{
+			name: "invalid igdb api timeout",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.IGDB.Timeout = 0
+			},
+			wantError: "IGDB_API_TIMEOUT must be greater than 0",
+		},
+		{
+			name: "missing sched fetch igdb games",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Scheduler.FetchIGDBGames = ""
+			},
+			wantError: "SCHED_FETCH_IGDB_GAMES is required",
+		},
+		{
+			name: "missing sched update trending index",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Scheduler.UpdateTrendingIndex = ""
+			},
+			wantError: "SCHED_UPDATE_TRENDING_INDEX is required",
+		},
+		{
+			name: "missing sched update game info",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Scheduler.UpdateGameInfo = ""
+			},
+			wantError: "SCHED_UPDATE_GAME_INFO is required",
+		},
+		{
+			name: "missing sched process moderation",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Scheduler.ProcessModeration = ""
+			},
+			wantError: "SCHED_PROCESS_MODERATION is required",
+		},
+		{
+			name: "missing redis addr",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Redis.Address = ""
+			},
+			wantError: "REDIS_ADDR is required",
+		},
+		{
+			name: "invalid redis ttl",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Redis.TTL = -time.Second
+			},
+			wantError: "REDIS_TTL must be greater or equal to 0",
+		},
+		{
+			name: "missing graylog addr",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Graylog.Address = ""
+			},
+			wantError: "GRAYLOG_ADDR is required",
+		},
+		{
+			name: "missing s3 region",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.Region = ""
+			},
+			wantError: "S3_REGION is required",
+		},
+		{
+			name: "missing s3 access key id",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.AccessKeyID = ""
+			},
+			wantError: "S3_ACCESS_KEY_ID is required",
+		},
+		{
+			name: "missing s3 secret access key",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.SecretAccessKey = ""
+			},
+			wantError: "S3_SECRET_ACCESS_KEY is required",
+		},
+		{
+			name: "missing s3 endpoint",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.Endpoint = ""
+			},
+			wantError: "S3_ENDPOINT is required",
+		},
+		{
+			name: "missing s3 bucket name",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.BucketName = ""
+			},
+			wantError: "S3_BUCKET_NAME is required",
+		},
+		{
+			name: "missing s3 cdn base url",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.CDNBaseURL = ""
+			},
+			wantError: "S3_CDN_BASE_URL is required",
+		},
+		{
+			name: "invalid s3 cdn base url",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.CDNBaseURL = "%"
+			},
+			wantError: "S3_CDN_BASE_URL is invalid",
+		},
+		{
+			name: "invalid s3 timeout",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.S3.Timeout = 0
+			},
+			wantError: "S3_TIMEOUT must be greater than 0",
+		},
+		{
+			name: "missing openai api key",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.OpenAI.APIKey = ""
+			},
+			wantError: "OPENAI_API_KEY is required",
+		},
+		{
+			name: "missing openai api url",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.OpenAI.APIURL = ""
+			},
+			wantError: "OPENAI_API_URL is required",
+		},
+		{
+			name: "invalid openai api timeout",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.OpenAI.Timeout = 0
+			},
+			wantError: "OPENAI_API_TIMEOUT must be greater than 0",
+		},
+		{
+			name: "missing openai moderation model",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.OpenAI.ModerationModel = ""
+			},
+			wantError: "OPENAI_MODERATION_MODEL is required",
+		},
+		{
+			name: "missing openai vision model",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.OpenAI.VisionModel = ""
+			},
+			wantError: "OPENAI_VISION_MODEL is required",
+		},
+		{
+			name: "missing log level",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.Log.Level = ""
+			},
+			wantError: "LOG_LEVEL is required",
+		},
+		{
+			name: "missing authapi address",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.AuthAPI.Address = ""
+			},
+			wantError: "AUTHAPI_ADDRESS is required",
+		},
+		{
+			name: "invalid authapi timeout",
+			mutate: func(cfg *appconf.Cfg) {
+				cfg.AuthAPI.Timeout = 0
+			},
+			wantError: "AUTHAPI_TIMEOUT must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			if cfg == nil && tt.mutate != nil {
+				cfg = validTestCfg()
+			}
+			if tt.mutate != nil {
+				tt.mutate(cfg)
+			}
+
+			err := cfg.Validate()
+
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func validTestCfg() *appconf.Cfg {
+	return &appconf.Cfg{
+		Log: appconf.Log{
+			Level: "INFO",
+		},
+		DB: appconf.DB{
+			DSN: "postgres://user:password@localhost:5432/games?sslmode=disable",
+		},
+		Web: appconf.Web{
+			HTTPAddress:       "0.0.0.0:8000",
+			GRPCAddress:       "0.0.0.0:9000",
+			DebugAddress:      "0.0.0.0:6060",
+			ReadTimeout:       time.Second,
+			WriteTimeout:      time.Second,
+			AllowedCORSOrigin: "http://localhost:3000",
+		},
+		Zipkin: appconf.Zipkin{
+			ReporterURL: "http://localhost:9411/api/v2/spans",
+		},
+		IGDB: appconf.IGDB{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			TokenURL:     "https://id.twitch.tv/oauth2/token",
+			APIURL:       "https://api.igdb.com/v4/",
+			Timeout:      10 * time.Second,
+		},
+		Scheduler: appconf.Scheduler{
+			FetchIGDBGames:      "0 5 * * *",
+			UpdateTrendingIndex: "0 2 * * *",
+			UpdateGameInfo:      "0 1 * * *",
+			ProcessModeration:   "*/2 * * * *",
+		},
+		Redis: appconf.Redis{
+			Address:  "localhost:6379",
+			Password: "",
+			TTL:      2 * time.Hour,
+		},
+		Graylog: appconf.Graylog{
+			Address: "localhost:12201",
+		},
+		S3: appconf.S3{
+			Region:          "auto",
+			AccessKeyID:     "access-key",
+			SecretAccessKey: "secret-key",
+			Endpoint:        "https://s3.example.com",
+			BucketName:      "game-library",
+			CDNBaseURL:      "https://cdn.example.com",
+			Timeout:         10 * time.Second,
+		},
+		OpenAI: appconf.OpenAI{
+			APIKey:          "key",
+			APIURL:          "https://api.openai.com/v1",
+			ModerationModel: "omni-moderation-latest",
+			VisionModel:     "gpt-5-nano",
+			Timeout:         30 * time.Second,
+		},
+		AuthAPI: appconf.AuthAPI{
+			Address: "localhost:9001",
+			Timeout: time.Second,
+		},
+	}
+}

--- a/internal/client/authapi/client.go
+++ b/internal/client/authapi/client.go
@@ -20,30 +20,30 @@ type Config struct {
 
 // Client wraps a gRPC AuthApiService client
 type Client struct {
-	cfg  Config
-	conn *grpc.ClientConn
-	api  authapipb.AuthApiServiceClient
+	conn    *grpc.ClientConn
+	api     authapipb.AuthApiServiceClient
+	timeout time.Duration
 }
 
 // NewClient dials the authapi service and returns a ready client
-func NewClient(cfg Config) (*Client, error) {
-	if cfg.Address == "" {
+func NewClient(conf Config) (*Client, error) {
+	if conf.Address == "" {
 		return nil, errors.New("authapi address is required")
 	}
 
 	dialOpts := append([]grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	}, cfg.DialOptions...)
+	}, conf.DialOptions...)
 
-	conn, err := grpc.NewClient(cfg.Address, dialOpts...)
+	conn, err := grpc.NewClient(conf.Address, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("dial authapi: %w", err)
 	}
 
 	return &Client{
-		cfg:  cfg,
-		conn: conn,
-		api:  authapipb.NewAuthApiServiceClient(conn),
+		timeout: conf.Timeout,
+		conn:    conn,
+		api:     authapipb.NewAuthApiServiceClient(conn),
 	}, nil
 }
 
@@ -62,7 +62,7 @@ func (c *Client) VerifyToken(ctx context.Context, token string) (bool, error) {
 		return false, errors.New("token is required")
 	}
 
-	ctx, cancel := CtxWithTimeout(ctx, c.cfg.Timeout)
+	ctx, cancel := CtxWithTimeout(ctx, c.timeout)
 	defer cancel()
 
 	req := &authapipb.VerifyTokenRequest{}

--- a/internal/client/authapi/client.go
+++ b/internal/client/authapi/client.go
@@ -11,8 +11,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const defaultTimeout = 5 * time.Second
-
 // Config - settings for authapi service
 type Config struct {
 	Address     string
@@ -31,9 +29,6 @@ type Client struct {
 func NewClient(cfg Config) (*Client, error) {
 	if cfg.Address == "" {
 		return nil, errors.New("authapi address is required")
-	}
-	if cfg.Timeout <= 0 {
-		cfg.Timeout = defaultTimeout
 	}
 
 	dialOpts := append([]grpc.DialOption{

--- a/internal/client/authapi/client_test.go
+++ b/internal/client/authapi/client_test.go
@@ -42,7 +42,7 @@ func TestVerifyToken(t *testing.T) {
 		assert.NoError(t, client.Close())
 	})
 
-	valid, err := client.VerifyToken(context.Background(), "jwt-token")
+	valid, err := client.VerifyToken(t.Context(), "jwt-token")
 	require.NoError(t, err)
 	assert.True(t, valid)
 }
@@ -60,13 +60,13 @@ func TestVerifyTokenRequiresToken(t *testing.T) {
 		assert.NoError(t, client.Close())
 	})
 
-	_, err = client.VerifyToken(context.Background(), "")
+	_, err = client.VerifyToken(t.Context(), "")
 	require.Error(t, err)
 }
 
 func TestCtxWithTimeout(t *testing.T) {
 	t.Run("sets timeout when context has no deadline", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		timeout := 100 * time.Millisecond
 
 		newCtx, cancel := authapi.CtxWithTimeout(ctx, timeout)
@@ -79,7 +79,7 @@ func TestCtxWithTimeout(t *testing.T) {
 
 	t.Run("respects existing deadline", func(t *testing.T) {
 		existingDeadline := time.Now().Add(200 * time.Millisecond)
-		ctx, cancel := context.WithDeadline(context.Background(), existingDeadline)
+		ctx, cancel := context.WithDeadline(t.Context(), existingDeadline)
 		defer cancel()
 
 		newCtx, newCancel := authapi.CtxWithTimeout(ctx, 100*time.Millisecond)
@@ -91,7 +91,7 @@ func TestCtxWithTimeout(t *testing.T) {
 	})
 
 	t.Run("returns working cancel function when deadline exists", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 		defer cancel()
 
 		newCtx, newCancel := authapi.CtxWithTimeout(ctx, 100*time.Millisecond)
@@ -107,7 +107,7 @@ func TestCtxWithTimeout(t *testing.T) {
 	})
 
 	t.Run("handles zero timeout", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		newCtx, cancel := authapi.CtxWithTimeout(ctx, 0)
 		defer cancel()
@@ -117,7 +117,7 @@ func TestCtxWithTimeout(t *testing.T) {
 	})
 
 	t.Run("handles negative timeout", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		newCtx, cancel := authapi.CtxWithTimeout(ctx, -1*time.Second)
 		defer cancel()
@@ -127,7 +127,7 @@ func TestCtxWithTimeout(t *testing.T) {
 	})
 
 	t.Run("cancel function can be called multiple times", func(_ *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, cancel := authapi.CtxWithTimeout(ctx, 100*time.Millisecond)
 
@@ -140,7 +140,7 @@ func startServer(t *testing.T, valid bool) (string, func()) {
 	t.Helper()
 
 	lc := &net.ListenConfig{}
-	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	lis, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	srv := grpc.NewServer()

--- a/internal/client/igdbapi/client.go
+++ b/internal/client/igdbapi/client.go
@@ -30,10 +30,13 @@ var tracer = otel.Tracer("igdbapi")
 
 // Client represents dependencies for igdb client
 type Client struct {
-	log        *zap.Logger
-	conf       appconf.IGDB
-	token      *tokenInfo
-	httpClient *http.Client
+	log          *zap.Logger
+	clientID     string
+	clientSecret string
+	tokenURL     string
+	apiURL       string
+	token        *tokenInfo
+	httpClient   *http.Client
 }
 
 // New constructs Client instance
@@ -44,10 +47,13 @@ func New(log *zap.Logger, conf appconf.IGDB) (*Client, error) {
 	}
 
 	return &Client{
-		log:        log,
-		token:      &tokenInfo{},
-		conf:       conf,
-		httpClient: client,
+		log:          log,
+		token:        &tokenInfo{},
+		clientID:     conf.ClientID,
+		clientSecret: conf.ClientSecret,
+		tokenURL:     conf.TokenURL,
+		apiURL:       conf.APIURL,
+		httpClient:   client,
 	}, nil
 }
 
@@ -66,7 +72,7 @@ func (c *Client) GetTopRatedGames(ctx context.Context, platformsIDs []int64, rel
 	}
 	platforms := strings.Join(platformsStr, ",")
 
-	reqURL, err := url.JoinPath(c.conf.APIURL, gamesEndpoint)
+	reqURL, err := url.JoinPath(c.apiURL, gamesEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("join url path: %v", err)
 	}
@@ -123,7 +129,7 @@ func (c *Client) GetGameInfoForUpdate(ctx context.Context, igdbID int64) (GameIn
 	ctx, span := tracer.Start(ctx, "getGameInfoForUpdate")
 	defer span.End()
 
-	reqURL, err := url.JoinPath(c.conf.APIURL, gamesEndpoint)
+	reqURL, err := url.JoinPath(c.apiURL, gamesEndpoint)
 	if err != nil {
 		return GameInfoForUpdate{}, fmt.Errorf("join url path: %v", err)
 	}
@@ -179,7 +185,7 @@ func (c *Client) CompanyExists(ctx context.Context, companyName string) (bool, e
 	ctx, span := tracer.Start(ctx, "companyExists")
 	defer span.End()
 
-	reqURL, err := url.JoinPath(c.conf.APIURL, companiesEndpoint)
+	reqURL, err := url.JoinPath(c.apiURL, companiesEndpoint)
 	if err != nil {
 		return false, fmt.Errorf("join url path: %v", err)
 	}
@@ -282,7 +288,7 @@ func (c *Client) setAuthHeaders(ctx context.Context, req *http.Request) error {
 	if err != nil {
 		return fmt.Errorf("getting igdb access token: %v", err)
 	}
-	req.Header.Set("Client-ID", c.conf.ClientID)
+	req.Header.Set("Client-ID", c.clientID)
 	req.Header.Set("Authorization", "Bearer "+token)
 	return nil
 }
@@ -297,7 +303,7 @@ func (c *Client) accessToken(ctx context.Context) (string, error) {
 		return token, nil
 	}
 
-	reqURL := c.conf.TokenURL
+	reqURL := c.tokenURL
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("error creating igdb get token request: %v", err)
@@ -305,13 +311,13 @@ func (c *Client) accessToken(ctx context.Context) (string, error) {
 
 	q := req.URL.Query()
 	q.Add("grant_type", "client_credentials")
-	q.Add("client_id", c.conf.ClientID)
-	q.Add("client_secret", c.conf.ClientSecret)
+	q.Add("client_id", c.clientID)
+	q.Add("client_secret", c.clientSecret)
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		c.log.Error("calling token api", zap.String("url", c.conf.TokenURL), zap.Error(err))
+		c.log.Error("calling token api", zap.String("url", c.tokenURL), zap.Error(err))
 		return "", fmt.Errorf("token api unavailable: %v", err)
 	}
 	defer func() {

--- a/internal/client/igdbapi/client.go
+++ b/internal/client/igdbapi/client.go
@@ -20,10 +20,6 @@ import (
 )
 
 const (
-	defaultTimeout = 10 * time.Second
-)
-
-const (
 	gamesEndpoint     = "games"
 	companiesEndpoint = "companies"
 
@@ -44,7 +40,7 @@ type Client struct {
 func New(log *zap.Logger, conf appconf.IGDB) (*Client, error) {
 	client := &http.Client{
 		Transport: observability.NewTransport("igdb", observability.WithOtel()),
-		Timeout:   defaultTimeout,
+		Timeout:   conf.Timeout,
 	}
 
 	return &Client{

--- a/internal/client/igdbapi/client.go
+++ b/internal/client/igdbapi/client.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/OutOfStack/game-library/internal/appconf"
 	"github.com/OutOfStack/game-library/internal/pkg/observability"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 )
@@ -44,7 +43,7 @@ type Client struct {
 // New constructs Client instance
 func New(log *zap.Logger, conf appconf.IGDB) (*Client, error) {
 	client := &http.Client{
-		Transport: observability.NewMonitoredTransport(otelhttp.NewTransport(http.DefaultTransport), "igdb"),
+		Transport: observability.NewTransport("igdb", observability.WithOtel()),
 		Timeout:   defaultTimeout,
 	}
 

--- a/internal/client/openaiapi/client.go
+++ b/internal/client/openaiapi/client.go
@@ -41,7 +41,6 @@ type Client struct {
 // New creates new OpenAI client
 func New(log *zap.Logger, cfg appconf.OpenAI) *Client {
 	httpClient := &http.Client{
-		Timeout:   defaultTimeout,
 		Transport: observability.NewTransport("openai", observability.WithOtel()),
 	}
 	client := openai.NewClient(

--- a/internal/client/openaiapi/client.go
+++ b/internal/client/openaiapi/client.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/OutOfStack/game-library/internal/appconf"
 	"github.com/OutOfStack/game-library/internal/model"
+	"github.com/OutOfStack/game-library/internal/pkg/observability"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
@@ -21,6 +24,8 @@ import (
 const (
 	gameSummaryMaxLen = 2000
 	maxVisionTokens   = 1000
+
+	defaultTimeout = 30 * time.Second
 )
 
 var tracer = otel.Tracer("openaiapi")
@@ -35,9 +40,15 @@ type Client struct {
 
 // New creates new OpenAI client
 func New(log *zap.Logger, cfg appconf.OpenAI) *Client {
+	httpClient := &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: observability.NewTransport("openai", observability.WithOtel()),
+	}
 	client := openai.NewClient(
 		option.WithAPIKey(cfg.APIKey),
 		option.WithBaseURL(cfg.APIURL),
+		option.WithRequestTimeout(defaultTimeout),
+		option.WithHTTPClient(httpClient),
 	)
 
 	return &Client{

--- a/internal/client/openaiapi/client.go
+++ b/internal/client/openaiapi/client.go
@@ -36,21 +36,22 @@ type Client struct {
 }
 
 // New creates new OpenAI client
-func New(log *zap.Logger, cfg appconf.OpenAI) *Client {
+func New(log *zap.Logger, conf appconf.OpenAI) *Client {
 	httpClient := &http.Client{
 		Transport: observability.NewTransport("openai", observability.WithOtel()),
+		Timeout:   conf.Timeout,
 	}
 	client := openai.NewClient(
-		option.WithAPIKey(cfg.APIKey),
-		option.WithBaseURL(cfg.APIURL),
-		option.WithRequestTimeout(cfg.Timeout),
+		option.WithAPIKey(conf.APIKey),
+		option.WithBaseURL(conf.APIURL),
+		option.WithRequestTimeout(conf.Timeout),
 		option.WithHTTPClient(httpClient),
 	)
 
 	return &Client{
 		client:          &client,
-		moderationModel: cfg.ModerationModel,
-		visionModel:     cfg.VisionModel,
+		moderationModel: conf.ModerationModel,
+		visionModel:     conf.VisionModel,
 		log:             log,
 	}
 }

--- a/internal/client/openaiapi/client.go
+++ b/internal/client/openaiapi/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/OutOfStack/game-library/internal/appconf"
 	"github.com/OutOfStack/game-library/internal/model"
@@ -24,8 +23,6 @@ import (
 const (
 	gameSummaryMaxLen = 2000
 	maxVisionTokens   = 1000
-
-	defaultTimeout = 30 * time.Second
 )
 
 var tracer = otel.Tracer("openaiapi")
@@ -46,7 +43,7 @@ func New(log *zap.Logger, cfg appconf.OpenAI) *Client {
 	client := openai.NewClient(
 		option.WithAPIKey(cfg.APIKey),
 		option.WithBaseURL(cfg.APIURL),
-		option.WithRequestTimeout(defaultTimeout),
+		option.WithRequestTimeout(cfg.Timeout),
 		option.WithHTTPClient(httpClient),
 	)
 

--- a/internal/client/redis/client.go
+++ b/internal/client/redis/client.go
@@ -23,10 +23,10 @@ type Client struct {
 }
 
 // New creates new redis client instance
-func New(cfg appconf.Redis) (*Client, error) {
+func New(conf appconf.Redis) (*Client, error) {
 	rdb := redis.NewClient(&redis.Options{
-		Addr:     cfg.Address,
-		Password: cfg.Password,
+		Addr:     conf.Address,
+		Password: conf.Password,
 		MaintNotificationsConfig: &maintnotifications.Config{
 			Mode: maintnotifications.ModeDisabled,
 		},
@@ -34,7 +34,7 @@ func New(cfg appconf.Redis) (*Client, error) {
 
 	return &Client{
 		rdb: rdb,
-		ttl: cfg.TTL,
+		ttl: conf.TTL,
 	}, nil
 }
 

--- a/internal/client/s3/client.go
+++ b/internal/client/s3/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
@@ -38,7 +37,7 @@ type Client struct {
 // New constructs Client instance
 func New(log *zap.Logger, conf appconf.S3) (*Client, error) {
 	httpClient := &http.Client{
-		Transport: observability.NewMonitoredTransport(otelhttp.NewTransport(http.DefaultTransport), "s3"),
+		Transport: observability.NewTransport("s3", observability.WithOtel()),
 		Timeout:   defaultTimeout,
 	}
 

--- a/internal/client/s3/client.go
+++ b/internal/client/s3/client.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"time"
 
 	"github.com/OutOfStack/game-library/internal/appconf"
 	"github.com/OutOfStack/game-library/internal/pkg/observability"
@@ -18,10 +17,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
-)
-
-const (
-	defaultTimeout = 10 * time.Second
 )
 
 var tracer = otel.Tracer("s3")
@@ -38,7 +33,7 @@ type Client struct {
 func New(log *zap.Logger, conf appconf.S3) (*Client, error) {
 	httpClient := &http.Client{
 		Transport: observability.NewTransport("s3", observability.WithOtel()),
-		Timeout:   defaultTimeout,
+		Timeout:   conf.Timeout,
 	}
 
 	ctx := context.Background()

--- a/internal/middleware/metrics.go
+++ b/internal/middleware/metrics.go
@@ -2,66 +2,68 @@ package middleware
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
+	"github.com/OutOfStack/game-library/internal/pkg/observability"
+	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	methodLabel     = "method"
-	pathLabel       = "path"
-	statusCodeLabel = "status_code"
-)
-
 var (
-	requestsTotal = promauto.NewCounterVec(
+	httpServerRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_requests_total",
+			Name: "http_server_requests_total",
 			Help: "Total number of HTTP requests",
 		},
-		[]string{methodLabel, pathLabel},
+		[]string{observability.MethodLabel, observability.PathLabel, observability.CodeLabel},
 	)
-	errorsTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "http_errors_total",
-			Help: "Total number of HTTP errors",
-		},
-		[]string{methodLabel, pathLabel, statusCodeLabel},
-	)
-	serverErrorsTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "http_server_errors_total",
-			Help: "Total number of server errors (5xx)",
-		},
-		[]string{methodLabel, pathLabel, statusCodeLabel},
-	)
-	responseDuration = promauto.NewHistogramVec(
+	httpServerRequestDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_response_duration_seconds",
+			Name:    "http_server_request_duration_seconds",
 			Help:    "Histogram of response duration for HTTP requests",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{methodLabel, pathLabel, statusCodeLabel},
+		[]string{observability.MethodLabel, observability.PathLabel},
 	)
+	httpServerInFlight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "http_server_in_flight_requests",
+		Help: "Number of HTTP requests currently being processed",
+	})
 )
 
-// wraps http.ResponseWriter to capture the HTTP status code
+// statusCodeResponseWriter wraps http.ResponseWriter to capture the HTTP status code
 type statusCodeResponseWriter struct {
 	http.ResponseWriter
-	StatusCode int
+	statusCode int
 }
 
 // WriteHeader writes the HTTP status code to the response
 func (w *statusCodeResponseWriter) WriteHeader(statusCode int) {
-	w.StatusCode = statusCode
+	w.statusCode = statusCode
 	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Flush implements http.Flusher interface for streaming responses
+func (w *statusCodeResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap returns the underlying ResponseWriter for middleware compatibility
+func (w *statusCodeResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }
 
 // Metrics records metrics for each HTTP request
 func Metrics(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rw := &statusCodeResponseWriter{ResponseWriter: w, StatusCode: http.StatusOK}
+		rw := &statusCodeResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+		httpServerInFlight.Inc()
+		defer httpServerInFlight.Dec()
 
 		start := time.Now()
 
@@ -69,15 +71,15 @@ func Metrics(next http.Handler) http.Handler {
 
 		duration := time.Since(start).Seconds()
 
-		requestsTotal.WithLabelValues(r.Method, r.URL.Path).Inc()
-
-		if rw.StatusCode >= 400 {
-			errorsTotal.WithLabelValues(r.Method, r.URL.Path, http.StatusText(rw.StatusCode)).Inc()
-		}
-		if rw.StatusCode >= 500 {
-			serverErrorsTotal.WithLabelValues(r.Method, r.URL.Path, http.StatusText(rw.StatusCode)).Inc()
+		// use chi's route pattern to avoid high cardinality
+		path := chi.RouteContext(r.Context()).RoutePattern()
+		if path == "" {
+			path = r.URL.Path
 		}
 
-		responseDuration.WithLabelValues(r.Method, r.URL.Path, http.StatusText(rw.StatusCode)).Observe(duration)
+		code := strconv.Itoa(rw.statusCode)
+
+		httpServerRequestsTotal.WithLabelValues(r.Method, path, code).Inc()
+		httpServerRequestDuration.WithLabelValues(r.Method, path).Observe(duration)
 	})
 }

--- a/internal/middleware/metrics.go
+++ b/internal/middleware/metrics.go
@@ -72,9 +72,10 @@ func Metrics(next http.Handler) http.Handler {
 		duration := time.Since(start).Seconds()
 
 		// use chi's route pattern to avoid high cardinality
-		path := chi.RouteContext(r.Context()).RoutePattern()
-		if path == "" {
-			path = r.URL.Path
+		path := r.URL.Path
+		chiCtx := chi.RouteContext(r.Context())
+		if chiCtx != nil {
+			path = chiCtx.RoutePattern()
 		}
 
 		code := strconv.Itoa(rw.statusCode)

--- a/internal/middleware/metrics_test.go
+++ b/internal/middleware/metrics_test.go
@@ -1,0 +1,129 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OutOfStack/game-library/internal/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics_RecordsStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"OK", http.StatusOK},
+		{"Created", http.StatusCreated},
+		{"BadRequest", http.StatusBadRequest},
+		{"NotFound", http.StatusNotFound},
+		{"InternalServerError", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := middleware.Metrics(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.statusCode, rr.Code)
+		})
+	}
+}
+
+func TestMetrics_DefaultStatusCode(t *testing.T) {
+	handler := middleware.Metrics(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// handler writes body without explicit WriteHeader
+		_, _ = w.Write([]byte("OK"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestMetrics_WithChiRoutePattern(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(middleware.Metrics)
+	r.Get("/games/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/games/123", nil)
+	rr := httptest.NewRecorder()
+
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestMetrics_DifferentMethods(t *testing.T) {
+	methods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			handler := middleware.Metrics(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(method, "/test", nil)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
+}
+
+func TestMetrics_Flusher(t *testing.T) {
+	handler := middleware.Metrics(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		assert.True(t, ok, "ResponseWriter should implement http.Flusher")
+		if !ok {
+			return
+		}
+		flusher.Flush()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestMetrics_ResponseBodyWritten(t *testing.T) {
+	expectedBody := "Hello, World!"
+
+	handler := middleware.Metrics(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(expectedBody))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, expectedBody, rr.Body.String())
+}

--- a/internal/pkg/observability/transport.go
+++ b/internal/pkg/observability/transport.go
@@ -3,82 +3,124 @@ package observability
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// metrics labels
+const (
+	ClientLabel = "client"
+	URLLabel    = "url"
+	MethodLabel = "method"
+	CodeLabel   = "code"
+	PathLabel   = "path"
 )
 
 const (
-	clientLabel = "client"
-	urlLabel    = "url"
-
 	maxURLSegments = 4
 )
 
 var (
-	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "http_client_duration_seconds",
-		Help:    "Duration of HTTP client calls",
-		Buckets: prometheus.DefBuckets,
-	}, []string{clientLabel, urlLabel})
+	httpClientInFlight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "http_client_in_flight_requests",
+		Help: "A gauge of in-flight requests for the HTTP client",
+	}, []string{ClientLabel})
 
-	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	httpClientRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "http_client_requests_total",
 		Help: "Total number of HTTP client requests",
-	}, []string{clientLabel, urlLabel})
+	}, []string{ClientLabel, MethodLabel, CodeLabel, URLLabel})
 
-	httpRequestErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "http_client_errors_total",
-		Help: "Total number of HTTP client requests that resulted in an error",
-	}, []string{clientLabel, urlLabel})
+	httpClientRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "http_client_request_duration_seconds",
+		Help:    "A histogram of HTTP client request latencies",
+		Buckets: prometheus.DefBuckets,
+	}, []string{ClientLabel, MethodLabel, URLLabel})
+
+	httpClientRequestErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_client_request_errors_total",
+		Help: "Total number of HTTP client transport errors",
+	}, []string{ClientLabel, MethodLabel, URLLabel})
 )
 
-// MonitoredTransport wraps an http.RoundTripper to add metrics
-type MonitoredTransport struct {
+// TransportOption configures a monitoredTransport
+type TransportOption func(*transportOptions)
+
+type transportOptions struct {
+	rt       http.RoundTripper
+	withOtel bool
+}
+
+// WithRoundTripper sets the base RoundTripper to wrap
+func WithRoundTripper(rt http.RoundTripper) TransportOption {
+	return func(o *transportOptions) {
+		o.rt = rt
+	}
+}
+
+// WithOtel wraps the transport with OpenTelemetry instrumentation for trace propagation
+func WithOtel() TransportOption {
+	return func(o *transportOptions) {
+		o.withOtel = true
+	}
+}
+
+// transport wraps an http.RoundTripper to add metrics
+type transport struct {
 	rt         http.RoundTripper
 	clientName string
 }
 
-// NewMonitoredTransport creates a new instance of MonitoredTransport
-func NewMonitoredTransport(rt http.RoundTripper, clientName string) *MonitoredTransport {
-	if rt == nil {
-		rt = http.DefaultTransport
+// NewTransport creates a new instrumented http.RoundTripper with Prometheus metrics
+func NewTransport(clientName string, opts ...TransportOption) http.RoundTripper {
+	options := &transportOptions{
+		rt: http.DefaultTransport,
 	}
-	return &MonitoredTransport{
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	rt := options.rt
+	if options.withOtel {
+		rt = otelhttp.NewTransport(rt)
+	}
+
+	return &transport{
 		rt:         rt,
 		clientName: clientName,
 	}
 }
 
-// RoundTrip implements the RoundTripper interface
-func (t *MonitoredTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+// RoundTrip implements the http.RoundTripper interface
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	labelURL := normalizeURL(*req.URL, maxURLSegments)
+	method := req.Method
 
-	// Increment the total requests counter
-	httpRequestsTotal.WithLabelValues(t.clientName, labelURL).Inc()
+	httpClientInFlight.WithLabelValues(t.clientName).Inc()
+	defer httpClientInFlight.WithLabelValues(t.clientName).Dec()
 
-	// Start timer
 	start := time.Now()
 	resp, err := t.rt.RoundTrip(req)
-	// Measure duration
 	duration := time.Since(start).Seconds()
 
-	// Set the duration metric
-	httpRequestDuration.WithLabelValues(t.clientName, labelURL).Observe(duration)
+	httpClientRequestDuration.WithLabelValues(t.clientName, method, labelURL).Observe(duration)
 
 	if err != nil {
-		// Increment the error counter
-		httpRequestErrorsTotal.WithLabelValues(t.clientName, labelURL).Inc()
-		return nil, err
+		httpClientRequestErrors.WithLabelValues(t.clientName, method, labelURL).Inc()
+	} else if resp != nil {
+		httpClientRequestsTotal.WithLabelValues(t.clientName, method, strconv.Itoa(resp.StatusCode), labelURL).Inc()
 	}
 
 	return resp, err
 }
 
-func normalizeURL(url url.URL, maxSegments int) string {
-	parts := strings.Split(url.Path, "/")
+func normalizeURL(u url.URL, maxSegments int) string {
+	parts := strings.Split(u.Path, "/")
 	var segments []string
 	for _, part := range parts {
 		if part != "" {
@@ -90,10 +132,8 @@ func normalizeURL(url url.URL, maxSegments int) string {
 		segments = segments[:maxSegments]
 	}
 
-	// Reconstruct the normalized path
-	url.Path = "/" + strings.Join(segments, "/")
-	// Remove query parameters if any
-	url.RawQuery = ""
+	u.Path = "/" + strings.Join(segments, "/")
+	u.RawQuery = ""
 
-	return url.String()
+	return u.String()
 }

--- a/internal/pkg/observability/transport_test.go
+++ b/internal/pkg/observability/transport_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -154,82 +153,6 @@ func TestRoundTrip_DifferentMethods(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
-		})
-	}
-}
-
-func TestNormalizeURL(t *testing.T) {
-	tests := []struct {
-		name        string
-		inputURL    string
-		maxSegments int
-		expected    string
-	}{
-		{
-			name:        "simple path",
-			inputURL:    "http://example.com/api/v1/games",
-			maxSegments: 4,
-			expected:    "http://example.com/api/v1/games",
-		},
-		{
-			name:        "path exceeds max segments",
-			inputURL:    "http://example.com/api/v1/games/123/reviews/456",
-			maxSegments: 4,
-			expected:    "http://example.com/api/v1/games/123",
-		},
-		{
-			name:        "strips query params",
-			inputURL:    "http://example.com/api/games?page=1&limit=10",
-			maxSegments: 4,
-			expected:    "http://example.com/api/games",
-		},
-		{
-			name:        "empty path",
-			inputURL:    "http://example.com",
-			maxSegments: 4,
-			expected:    "http://example.com/",
-		},
-		{
-			name:        "root path",
-			inputURL:    "http://example.com/",
-			maxSegments: 4,
-			expected:    "http://example.com/",
-		},
-		{
-			name:        "trailing slash",
-			inputURL:    "http://example.com/api/v1/",
-			maxSegments: 4,
-			expected:    "http://example.com/api/v1",
-		},
-		{
-			name:        "max segments zero",
-			inputURL:    "http://example.com/api/v1/games",
-			maxSegments: 0,
-			expected:    "http://example.com/",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := &mockRoundTripper{
-				resp: newMockResponse(http.StatusOK),
-			}
-
-			// we test normalizeURL indirectly through RoundTrip since it's unexported
-			// the URL normalization happens inside RoundTrip
-			rt := observability.NewTransport("test", observability.WithRoundTripper(mock))
-
-			parsedURL, err := url.Parse(tt.inputURL)
-			require.NoError(t, err)
-
-			req := &http.Request{
-				Method: http.MethodGet,
-				URL:    parsedURL,
-			}
-
-			resp, err := rt.RoundTrip(req)
-			require.NoError(t, err)
-			defer resp.Body.Close()
 		})
 	}
 }

--- a/internal/pkg/observability/transport_test.go
+++ b/internal/pkg/observability/transport_test.go
@@ -1,0 +1,235 @@
+package observability_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/OutOfStack/game-library/internal/pkg/observability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRoundTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (m *mockRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return m.resp, m.err
+}
+
+func newMockResponse(statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+}
+
+func TestNewTransport_DefaultTransport(t *testing.T) {
+	rt := observability.NewTransport("test-client")
+
+	require.NotNil(t, rt)
+}
+
+func TestNewTransport_WithCustomRoundTripper(t *testing.T) {
+	mock := &mockRoundTripper{
+		resp: newMockResponse(http.StatusOK),
+	}
+
+	rt := observability.NewTransport("test-client", observability.WithRoundTripper(mock))
+
+	require.NotNil(t, rt)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/api/test", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewTransport_WithOtel(t *testing.T) {
+	rt := observability.NewTransport("test-client", observability.WithOtel())
+
+	require.NotNil(t, rt)
+}
+
+func TestRoundTrip_Success(t *testing.T) {
+	mock := &mockRoundTripper{
+		resp: newMockResponse(http.StatusOK),
+	}
+
+	rt := observability.NewTransport("test-client", observability.WithRoundTripper(mock))
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/api/v1/games", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRoundTrip_Error(t *testing.T) {
+	expectedErr := errors.New("connection refused")
+	mock := &mockRoundTripper{
+		err: expectedErr,
+	}
+
+	rt := observability.NewTransport("test-client", observability.WithRoundTripper(mock))
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/api/v1/games", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestRoundTrip_DifferentStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"OK", http.StatusOK},
+		{"Created", http.StatusCreated},
+		{"BadRequest", http.StatusBadRequest},
+		{"NotFound", http.StatusNotFound},
+		{"InternalServerError", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRoundTripper{
+				resp: newMockResponse(tt.statusCode),
+			}
+
+			rt := observability.NewTransport("test-client", observability.WithRoundTripper(mock))
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/test", nil)
+			require.NoError(t, err)
+
+			resp, err := rt.RoundTrip(req)
+
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tt.statusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestRoundTrip_DifferentMethods(t *testing.T) {
+	methods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			mock := &mockRoundTripper{
+				resp: newMockResponse(http.StatusOK),
+			}
+
+			rt := observability.NewTransport("test-client", observability.WithRoundTripper(mock))
+
+			req, err := http.NewRequestWithContext(t.Context(), method, "http://example.com/test", nil)
+			require.NoError(t, err)
+
+			resp, err := rt.RoundTrip(req)
+
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputURL    string
+		maxSegments int
+		expected    string
+	}{
+		{
+			name:        "simple path",
+			inputURL:    "http://example.com/api/v1/games",
+			maxSegments: 4,
+			expected:    "http://example.com/api/v1/games",
+		},
+		{
+			name:        "path exceeds max segments",
+			inputURL:    "http://example.com/api/v1/games/123/reviews/456",
+			maxSegments: 4,
+			expected:    "http://example.com/api/v1/games/123",
+		},
+		{
+			name:        "strips query params",
+			inputURL:    "http://example.com/api/games?page=1&limit=10",
+			maxSegments: 4,
+			expected:    "http://example.com/api/games",
+		},
+		{
+			name:        "empty path",
+			inputURL:    "http://example.com",
+			maxSegments: 4,
+			expected:    "http://example.com/",
+		},
+		{
+			name:        "root path",
+			inputURL:    "http://example.com/",
+			maxSegments: 4,
+			expected:    "http://example.com/",
+		},
+		{
+			name:        "trailing slash",
+			inputURL:    "http://example.com/api/v1/",
+			maxSegments: 4,
+			expected:    "http://example.com/api/v1",
+		},
+		{
+			name:        "max segments zero",
+			inputURL:    "http://example.com/api/v1/games",
+			maxSegments: 0,
+			expected:    "http://example.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRoundTripper{
+				resp: newMockResponse(http.StatusOK),
+			}
+
+			// we test normalizeURL indirectly through RoundTrip since it's unexported
+			// the URL normalization happens inside RoundTrip
+			rt := observability.NewTransport("test", observability.WithRoundTripper(mock))
+
+			parsedURL, err := url.Parse(tt.inputURL)
+			require.NoError(t, err)
+
+			req := &http.Request{
+				Method: http.MethodGet,
+				URL:    parsedURL,
+			}
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+		})
+	}
+}

--- a/internal/taskprocessor/fetchgames_test.go
+++ b/internal/taskprocessor/fetchgames_test.go
@@ -21,7 +21,7 @@ func (s *TestSuite) TestStartFetchIGDBGames_Success() {
 		Name:     "fetch_igdb_games",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastReleasedAt":"%s"}`, lastReleasedAt.Format(time.RFC3339))),
+		Settings: fmt.Appendf(nil, `{"lastReleasedAt":"%s"}`, lastReleasedAt.Format(time.RFC3339)),
 	}
 
 	platforms := []model.Platform{

--- a/internal/taskprocessor/processmoderation_test.go
+++ b/internal/taskprocessor/processmoderation_test.go
@@ -88,7 +88,7 @@ func (s *TestSuite) TestStartProcessModeration_NoPendingRecords() {
 		Name:     "process_moderation",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedGameId":%d}`, lastProcessed)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedGameId":%d}`, lastProcessed),
 	}
 
 	s.storageMock.EXPECT().
@@ -127,7 +127,7 @@ func (s *TestSuite) TestStartProcessModeration_GetPendingError() {
 		Name:     "process_moderation",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedGameId":%d}`, lastProcessed)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedGameId":%d}`, lastProcessed),
 	}
 
 	expectedErr := errors.New("db failure")

--- a/internal/taskprocessor/updategameinfo_test.go
+++ b/internal/taskprocessor/updategameinfo_test.go
@@ -17,7 +17,7 @@ func (s *TestSuite) TestStartUpdateGameInfo_Success() {
 		Name:     "update_game_info",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31(), td.Int31()}
@@ -129,7 +129,7 @@ func (s *TestSuite) TestStartUpdateGameInfo_GetPlatformsError() {
 		Name:     "update_game_info",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31()}
@@ -154,7 +154,7 @@ func (s *TestSuite) TestStartUpdateGameInfo_GetGameError() {
 		Name:     "update_game_info",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31(), td.Int31()}
@@ -204,7 +204,7 @@ func (s *TestSuite) TestStartUpdateGameInfo_SkipGameWithZeroIGDBID() {
 		Name:     "update_game_info",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31(), td.Int31()}
@@ -260,7 +260,7 @@ func (s *TestSuite) TestStartUpdateGameInfo_IGDBAPIError() {
 		Name:     "update_game_info",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31(), td.Int31()}
@@ -317,7 +317,7 @@ func (s *TestSuite) TestStartUpdateGameInfo_UpdateGameIGDBInfoError() {
 		Name:     "update_game_info",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31(), td.Int31()}

--- a/internal/taskprocessor/updatetrendingindex_test.go
+++ b/internal/taskprocessor/updatetrendingindex_test.go
@@ -16,7 +16,7 @@ func (s *TestSuite) TestStartUpdateTrendingIndex_Success() {
 		Name:     "update_trending_index",
 		Status:   model.IdleTaskStatus,
 		RunCount: 0,
-		Settings: []byte(fmt.Sprintf(`{"lastProcessedId":%d}`, lastProcessedID)),
+		Settings: fmt.Appendf(nil, `{"lastProcessedId":%d}`, lastProcessedID),
 	}
 
 	gameIDs := []int32{td.Int31(), td.Int31(), td.Int31()}


### PR DESCRIPTION
* **Kubernetes Manifests Removal**: Removed all Kubernetes manifests related to Zipkin and Prometheus deployments, services, ingresses, config maps, and persistent volumes, streamlining the deployment configuration.
* **Observability Package Refactoring**: The internal/pkg/observability package was refactored to introduce a more flexible NewTransport function, allowing for optional OpenTelemetry integration and improved HTTP client metric collection.
* **HTTP Server Metrics Enhancement**: The HTTP server metrics middleware (internal/middleware/metrics.go) was significantly updated to use chi.RouteContext for more accurate path labeling, added an in-flight requests gauge, and refined metric names for better clarity.
* **Linter Configuration Update**: Updated golangci-lint to version v2.8 and enabled the modernize linter, with a specific exclusion for interface{} to any conversions.
* **Test Context Modernization**: Go test files were updated to consistently use t.Context() instead of context.Background() for better test context management and cancellation propagation.
* **New Test Coverage**: Added new test files for the refactored metrics middleware and the updated observability transport to ensure correctness and functionality.